### PR TITLE
Sn feature/admin data table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1168,6 +1168,11 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
+    "@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
     "@eslint/eslintrc": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.0.tgz",
@@ -1780,6 +1785,104 @@
         }
       }
     },
+    "@material-ui/core": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.1.tgz",
+      "integrity": "sha512-aesI8lOaaw0DRIfNG+Anepf61NH5Q+cmkxJOZvI1oHkmD5cKubkZ0C7INqFKjfFpSFlFnqHkTasoM7ogFAvzOg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/styles": "^4.11.1",
+        "@material-ui/system": "^4.9.14",
+        "@material-ui/types": "^5.1.0",
+        "@material-ui/utils": "^4.10.2",
+        "@types/react-transition-group": "^4.2.0",
+        "clsx": "^1.0.4",
+        "hoist-non-react-statics": "^3.3.2",
+        "popper.js": "1.16.1-lts",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0",
+        "react-transition-group": "^4.4.0"
+      }
+    },
+    "@material-ui/data-grid": {
+      "version": "4.0.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@material-ui/data-grid/-/data-grid-4.0.0-alpha.10.tgz",
+      "integrity": "sha512-paWjOv+b8lomLM7n5+pT1sEv1QQTLYxMGHlaWq1KUzYMfETOpjieUE8Szk5DdpqrR3N3PtDRPHQC5vTQLG71gA==",
+      "requires": {
+        "@material-ui/utils": "^5.0.0-alpha.14",
+        "prop-types": "^15.7.2",
+        "reselect": "^4.0.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@material-ui/utils": {
+          "version": "5.0.0-alpha.17",
+          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-5.0.0-alpha.17.tgz",
+          "integrity": "sha512-50DCE2m47pvGye6n7d4+nGu6DDvoqM+7m80lCRNViJlIXLINuWbz4VuhfLl1eHYSiAmh2Ls65IUn8u1yDJnJBg==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@types/prop-types": "^15.7.3",
+            "@types/react-is": "^16.7.1 || ^17.0.0",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.8.0 || ^17.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+        }
+      }
+    },
+    "@material-ui/styles": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.1.tgz",
+      "integrity": "sha512-GqzsFsVWT8jXa8OWAd1WD6WIaqtXr2mUPbRZ1EjkiM3Dlta4mCRaToDxkFVv6ZHfXlFjMJzdaIEvCpZOCvZTvg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@emotion/hash": "^0.8.0",
+        "@material-ui/types": "^5.1.0",
+        "@material-ui/utils": "^4.9.6",
+        "clsx": "^1.0.4",
+        "csstype": "^2.5.2",
+        "hoist-non-react-statics": "^3.3.2",
+        "jss": "^10.0.3",
+        "jss-plugin-camel-case": "^10.0.3",
+        "jss-plugin-default-unit": "^10.0.3",
+        "jss-plugin-global": "^10.0.3",
+        "jss-plugin-nested": "^10.0.3",
+        "jss-plugin-props-sort": "^10.0.3",
+        "jss-plugin-rule-value-function": "^10.0.3",
+        "jss-plugin-vendor-prefixer": "^10.0.3",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "@material-ui/system": {
+      "version": "4.9.14",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.9.14.tgz",
+      "integrity": "sha512-oQbaqfSnNlEkXEziDcJDDIy8pbvwUmZXWNqlmIwDqr/ZdCK8FuV3f4nxikUh7hvClKV2gnQ9djh5CZFTHkZj3w==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.9.6",
+        "csstype": "^2.5.2",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "@material-ui/types": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
+    },
+    "@material-ui/utils": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.10.2.tgz",
+      "integrity": "sha512-eg29v74P7W5r6a4tWWDAAfZldXIzfyO1am2fIsC39hdUUHm/33k6pGOKPbgDjg/U/4ifmgAePy/1OjkKN6rFRw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -2331,10 +2434,47 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.5.tgz",
       "integrity": "sha512-UEyp8LwZ4Dg30kVU2Q3amHHyTn1jEdhCIE59ANed76GaT1Vp76DD3ZWSAxgCrw6wJ0TqeoBpqmfUHiUDPs//HQ=="
     },
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+    },
     "@types/q": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
+    },
+    "@types/react": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.0.tgz",
+      "integrity": "sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==",
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
+          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+        }
+      }
+    },
+    "@types/react-is": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.0.tgz",
+      "integrity": "sha512-A0DQ1YWZ0RG2+PV7neAotNCIh8gZ3z7tQnDJyS2xRPDNtAtSPcJ9YyfMP8be36Ha0kQRzbZCrrTMznA4blqO5g==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-transition-group": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
+      "integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
+      "requires": {
+        "@types/react": "*"
+      }
     },
     "@types/resolve": {
       "version": "0.0.8",
@@ -4098,6 +4238,11 @@
         "shallow-clone": "^0.1.2"
       }
     },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -4611,6 +4756,15 @@
         }
       }
     },
+    "css-vendor": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
+      "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
+      "requires": {
+        "@babel/runtime": "^7.8.3",
+        "is-in-browser": "^1.0.2"
+      }
+    },
     "css-what": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
@@ -4787,6 +4941,11 @@
           "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
         }
       }
+    },
+    "csstype": {
+      "version": "2.6.14",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
+      "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -5126,6 +5285,22 @@
       "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
       "requires": {
         "utila": "~0.4"
+      }
+    },
+    "dom-helpers": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
+      "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
+          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+        }
       }
     },
     "dom-serializer": {
@@ -7579,6 +7754,11 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
     },
+    "hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -7683,6 +7863,14 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
       "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ=="
+    },
+    "indefinite-observable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/indefinite-observable/-/indefinite-observable-2.0.1.tgz",
+      "integrity": "sha512-G8vgmork+6H9S8lUAg1gtXEj2JxIQTo0g2PbFiYOdjkziSI0F7UYBiVwhZRuixhBCNGczAls34+5HJPyZysvxQ==",
+      "requires": {
+        "symbol-observable": "1.2.0"
+      }
     },
     "indent-string": {
       "version": "4.0.0",
@@ -8000,6 +8188,11 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-in-browser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
     },
     "is-module": {
       "version": "1.0.0",
@@ -9817,6 +10010,92 @@
         "verror": "1.10.0"
       }
     },
+    "jss": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.5.0.tgz",
+      "integrity": "sha512-B6151NvG+thUg3murLNHRPLxTLwQ13ep4SH5brj4d8qKtogOx/jupnpfkPGSHPqvcwKJaCLctpj2lEk+5yGwMw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "csstype": "^3.0.2",
+        "indefinite-observable": "^2.0.1",
+        "is-in-browser": "^1.1.3",
+        "tiny-warning": "^1.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
+          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+        }
+      }
+    },
+    "jss-plugin-camel-case": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.5.0.tgz",
+      "integrity": "sha512-GSjPL0adGAkuoqeYiXTgO7PlIrmjv5v8lA6TTBdfxbNYpxADOdGKJgIEkffhlyuIZHlPuuiFYTwUreLUmSn7rg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "hyphenate-style-name": "^1.0.3",
+        "jss": "10.5.0"
+      }
+    },
+    "jss-plugin-default-unit": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.5.0.tgz",
+      "integrity": "sha512-rsbTtZGCMrbcb9beiDd+TwL991NGmsAgVYH0hATrYJtue9e+LH/Gn4yFD1ENwE+3JzF3A+rPnM2JuD9L/SIIWw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.5.0"
+      }
+    },
+    "jss-plugin-global": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.5.0.tgz",
+      "integrity": "sha512-FZd9+JE/3D7HMefEG54fEC0XiQ9rhGtDHAT/ols24y8sKQ1D5KIw6OyXEmIdKFmACgxZV2ARQ5pAUypxkk2IFQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.5.0"
+      }
+    },
+    "jss-plugin-nested": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.5.0.tgz",
+      "integrity": "sha512-ejPlCLNlEGgx8jmMiDk/zarsCZk+DV0YqXfddpgzbO9Toamo0HweCFuwJ3ZO40UFOfqKwfpKMVH/3HUXgxkTMg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.5.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-props-sort": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.5.0.tgz",
+      "integrity": "sha512-kTLRvrOetFKz5vM88FAhLNeJIxfjhCepnvq65G7xsAQ/Wgy7HwO1BS/2wE5mx8iLaAWC6Rj5h16mhMk9sKdZxg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.5.0"
+      }
+    },
+    "jss-plugin-rule-value-function": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.5.0.tgz",
+      "integrity": "sha512-jXINGr8BSsB13JVuK274oEtk0LoooYSJqTBCGeBu2cG/VJ3+4FPs1gwLgsq24xTgKshtZ+WEQMVL34OprLidRA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.5.0",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-vendor-prefixer": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.5.0.tgz",
+      "integrity": "sha512-rux3gmfwDdOKCLDx0IQjTwTm03IfBa+Rm/hs747cOw5Q7O3RaTUIMPKjtVfc31Xr/XI9Abz2XEupk1/oMQ7zRA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "css-vendor": "^2.0.8",
+        "jss": "10.5.0"
+      }
+    },
     "jsx-ast-utils": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
@@ -11608,6 +11887,11 @@
         "ts-pnp": "^1.1.6"
       }
     },
+    "popper.js": {
+      "version": "1.16.1-lts",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
+      "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
+    },
     "portfinder": {
       "version": "1.0.28",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
@@ -13157,6 +13441,17 @@
         "workbox-webpack-plugin": "5.1.4"
       }
     },
+    "react-transition-group": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      }
+    },
     "reactjs-popup": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/reactjs-popup/-/reactjs-popup-2.0.4.tgz",
@@ -13574,6 +13869,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
     },
     "resolve": {
       "version": "1.18.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@material-ui/core": "^4.11.1",
+    "@material-ui/data-grid": "^4.0.0-alpha.10",
     "balloon-css": "^1.2.0",
     "node-sass": "^4.14.1",
     "prop-types": "^15.7.2",

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -46,3 +46,11 @@ export const resetErrorMsg = () => {
     type: 'RESET_ERROR',
   }
 }
+
+// Admin actions 
+export const setAdminJobList = (jobs) => {
+  return {
+    type: 'ADMIN_JOB_LIST',
+    jobs
+  }
+}

--- a/src/actions/actions.test.js
+++ b/src/actions/actions.test.js
@@ -50,6 +50,7 @@ describe('actions', () => {
 
     expect(result).toEqual(expectedAction);
   });
+
   it('should have a type of CLEAR_JOBS', () => {
     const expectedAction = {
       type: 'CLEAR_JOBS',
@@ -59,6 +60,7 @@ describe('actions', () => {
 
     expect(result).toEqual(expectedAction);
   });
+
   it('should have a type of SET_USER', () => {
     const info = {
       name: 'Taryn',
@@ -74,6 +76,7 @@ describe('actions', () => {
 
     expect(result).toEqual(expectedAction);
   });
+
   it('should have a type of LOGOUT_USER', () => {
     const expectedAction = {
       type: 'LOGOUT_USER'
@@ -83,6 +86,7 @@ describe('actions', () => {
 
     expect(result).toEqual(expectedAction);
   });
+
   it('should have a type of GET_INFO', () => {
 
     const jobId = "1"
@@ -175,4 +179,54 @@ describe('actions', () => {
 
     expect(result).toEqual(expectedAction);
   })
+
+  it('should have a type of ADMIN_JOB_LIST', () => {
+    const jobs = [
+      {
+        id: "1",
+        type: "job",
+        attributes: {
+          job_street: "\"123 Main St.\"",
+          job_city: "\"Denver\"",
+          job_state: "\"CO\"",
+          job_zip: "\"80218\"",
+          date_of_completion: "2020-01-01T04:05:06.000Z",
+          company_name: "\"Construction Co Inc LLC\"",
+          contact_name: "\"Tim\"",
+          material_cost: 100.0,
+          labor_cost: 200.0,
+          job_description: "\"New window\"",
+          job_id: "\"W1234\""
+        }
+      }
+    ];
+
+    const expectedAction = {
+      type: 'ADMIN_JOB_LIST',
+      jobs: [
+        {
+          id: "1",
+          type: "job",
+          attributes: {
+            job_street: "\"123 Main St.\"",
+            job_city: "\"Denver\"",
+            job_state: "\"CO\"",
+            job_zip: "\"80218\"",
+            date_of_completion: "2020-01-01T04:05:06.000Z",
+            company_name: "\"Construction Co Inc LLC\"",
+            contact_name: "\"Tim\"",
+            material_cost: 100.0,
+            labor_cost: 200.0,
+            job_description: "\"New window\"",
+            job_id: "\"W1234\""
+          }
+        }
+      ]
+    }
+
+    const result = actions.setAdminJobList(jobs);
+
+    expect(result).toEqual(expectedAction);
+  });
+
 })

--- a/src/components/AdminJobDetails/AdminJobDetails.js
+++ b/src/components/AdminJobDetails/AdminJobDetails.js
@@ -1,0 +1,66 @@
+import React from 'react';
+
+function AdminJobDetails(props) {
+  const { jobDetails, changeView } = props
+ 
+  return (
+    <div className='container'>
+      <button className='back-btn' onClick={() => changeView(true)}>
+        Back
+    </button>
+      <h2>Job Details</h2>
+      <h3 className='bold'>Job Site Name: </h3><p> {jobDetails.job_site_name ? jobDetails.job_site_name : "n/a"}</p>
+      <br />
+      <h3 className='bold'>Job Site Contact Name: </h3>
+      <p>{jobDetails.job_site_contact_name}</p><br />
+
+      {jobDetails.job_site_address_line_2 !== null &&
+        <>
+          <h3 className='bold'> Job Site Address: </h3>
+          <br />
+          <p>
+          {jobDetails.job_site_address},{jobDetails.job_site_address_line_2}<br />{jobDetails.job_site_city}, {jobDetails.job_site_state}, {jobDetails.job_site_zip_code}
+          </p>
+        </>
+      }
+      {jobDetails.job_site_address_line_2 === null &&
+        <>
+          <h3 className='bold'> Job Site Address: </h3><br />
+          <p>
+          {jobDetails.job_site_address},<br />{jobDetails.job_site_city}, {jobDetails.job_site_state}, {jobDetails.job_site_zip_code}
+          </p>
+        </>
+      }
+      <br />
+
+      <h3 className='bold'>Company Name: </h3>
+      <p>{jobDetails.client_company_name ? jobDetails.client_company_name : "n/a"}</p>
+      <br />
+      {jobDetails.business_address !== null &&
+        <>
+          <h3 className='bold'> Business Address: </h3><br />
+          <p>
+          {jobDetails.business_address}<br />{jobDetails.business_address_line_2}<br />{jobDetails.business_city}, {jobDetails.business_state}, {jobDetails.business_zip_code}
+          </p>
+        </>
+      }
+
+      <h3 className='bold'>Job Type: </h3>
+      <p>{jobDetails.job_type}</p><br />
+      <h3 className='bold'>Job Description: </h3>
+      <p>{jobDetails.description_of_work}</p><br />
+      <h3 className='bold'>Additional Info: </h3>
+      <p>{jobDetails.additional_info ? jobDetails.additional_info : "n/a"}</p><br />
+      <h3 className='bold'>Date of Substantial Completion: </h3>
+      <p>{jobDetails.completionDate}</p><br />
+      <h3 className='bold'>Labor Cost: </h3>
+      <p>{jobDetails.labor_cost ? `$${jobDetails.labor_cost}` : "n/a"}</p><br />
+      <h3 className='bold'>Materials Cost: </h3>
+      <p>{jobDetails.material_cost ? `$${jobDetails.material_cost}` : "n/a"}</p><br />
+      <h3 className='bold'>Total Cost: </h3>
+      <p>${jobDetails.total_cost}</p>
+    </div>
+  )
+}
+
+export default AdminJobDetails

--- a/src/components/AdminJobDetails/AdminJobDetails.js
+++ b/src/components/AdminJobDetails/AdminJobDetails.js
@@ -1,13 +1,15 @@
 import React from 'react';
+import Popup from 'reactjs-popup';
+import 'reactjs-popup/dist/index.css';
 
 function AdminJobDetails(props) {
-  const { jobDetails, changeView } = props
+  const { jobDetails, changeView, handleStatusChange } = props
  
   return (
     <div className='container'>
       <button className='back-btn' onClick={() => changeView(true)}>
         Back
-    </button>
+      </button>
       <h2>Job Details</h2>
       <h3 className='bold'>Job Site Name: </h3><p> {jobDetails.job_site_name ? jobDetails.job_site_name : "n/a"}</p>
       <br />
@@ -59,6 +61,22 @@ function AdminJobDetails(props) {
       <p>{jobDetails.material_cost ? `$${jobDetails.material_cost}` : "n/a"}</p><br />
       <h3 className='bold'>Total Cost: </h3>
       <p>${jobDetails.total_cost}</p>
+   
+      <div>
+        {/* Put buttons in their own component or leave here? */}
+        <Popup trigger={<button className='btn-submit'>Remove Job</button>} position="top left">
+          {close => (
+            <section className="popup-msg">
+              Are you sure you want to remove this job?
+              <button className="close" onClick={close}>Close
+              &times;
+              </button>
+              <button className="confirm" onClick={() => handleStatusChange(5)}>Confirm
+              </button>
+            </section>
+          )}
+        </Popup>
+      </div>
     </div>
   )
 }

--- a/src/components/AdminJobDetails/AdminJobDetails.js
+++ b/src/components/AdminJobDetails/AdminJobDetails.js
@@ -11,6 +11,8 @@ function AdminJobDetails(props) {
         Back
       </button>
       <h2>Job Details</h2>
+      <h3 className='bold'>Status: </h3><p>{jobDetails.status}</p>
+      <br /><br />
       <h3 className='bold'>Job Site Name: </h3><p> {jobDetails.job_site_name ? jobDetails.job_site_name : "n/a"}</p>
       <br />
       <h3 className='bold'>Job Site Contact Name: </h3>
@@ -63,7 +65,8 @@ function AdminJobDetails(props) {
       <p>${jobDetails.total_cost}</p>
    
       <div>
-        {/* Put buttons in their own component or leave here? */}
+        {/* REMOVE JOB BUTTON / STATUS CHANGE */}
+        {/* Render for all jobs: If cient wants to remove job (has been paid) */}
         <Popup trigger={<button className='btn-submit'>Remove Job</button>} position="top left">
           {close => (
             <section className="popup-msg">
@@ -76,6 +79,42 @@ function AdminJobDetails(props) {
             </section>
           )}
         </Popup>
+
+        {/* NOI FILED BUTTON / STATUS CHANGE */}
+        {/* if status is NOI requested render button */}
+        { (jobDetails.status ===  'NOI Requested') && 
+          <Popup trigger={<button className='btn-submit'>NOI Filed</button>} position="top left">
+            {close => (
+              <section className="popup-msg">
+                Please confirm that the NOI has been filed on behalf of {jobDetails.users_name}. 
+                <br />
+                <button className="close" onClick={close}>Close
+                &times;
+                </button>
+                <button className="confirm" onClick={() => handleStatusChange(0)}>Confirm
+                </button>
+              </section>
+            )}
+          </Popup>
+        }
+        
+        {/* LIEN FILED BUTTON / STATUS CHANGE */}
+        {/* if status is Lien Requested render button */}
+        { (jobDetails.status === 'Lien Requested') && 
+          <Popup trigger={<button className='btn-submit'>Lien Filed</button>} position="top left">
+            {close => (
+              <section className="popup-msg">
+                Please confirm that the Lien has been filed on behalf of {jobDetails.users_name}.
+                <br />
+                <button className="close" onClick={close}>Close
+                &times;
+                </button>
+                <button className="confirm" onClick={() => handleStatusChange(0)}>Confirm
+                </button>
+              </section>
+            )}
+          </Popup>
+        }
       </div>
     </div>
   )

--- a/src/components/AdminJobDetails/AdminJobDetails.test.js
+++ b/src/components/AdminJobDetails/AdminJobDetails.test.js
@@ -1,0 +1,228 @@
+import React from 'react';
+import AdminJobDetails from './AdminJobDetails.js';
+import thunk from 'redux-thunk';
+import { screen, render, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom'
+import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+// update status API call will need to be mocked once it's setup
+jest.mock('../../helpers/apiCalls')
+
+const middlewares = [thunk]
+const mockStore = configureMockStore(middlewares);
+
+describe('AdminJobDetails', () => {
+
+  it('should display job details', () => {
+    const store = mockStore({
+      adminJobList: [
+        {
+          id: "1",
+          job_type: 'Labor & Materials',
+          job_site_name: 'Home',
+          job_site_contact_name: 'Taryn',
+          job_site_address: '200 Washington St.',
+          job_site_address_line_2: null,
+          job_site_city: 'Denver',
+          job_site_state: 'CO',
+          job_site_zip_code: '80201',
+          completion_date: "2020-10-01T04:05:06.000Z",
+          material_cost: 200,
+          labor_cost: 300,
+          total_cost: 500,
+          description_of_work: 'Warehouse renovation',
+          client_company_name: 'Amazon',
+          business_address: '12 Tree Ave',
+          business_address_line_2: null,
+          business_city: 'Seattle',
+          business_state: 'WA',
+          business_zip_code: '99900',
+          additional_info: 'Received partial payment',
+          user_id: '12345',
+          status: 'Good Standing'
+        },
+      ]
+    })
+
+    const jobDetails = {
+      id: "1",
+      job_type: 'Labor & Materials',
+      job_site_name: 'Home',
+      job_site_contact_name: 'Taryn',
+      job_site_address: '200 Washington St.',
+      job_site_address_line_2: null,
+      job_site_city: 'Denver',
+      job_site_state: 'CO',
+      job_site_zip_code: '80201',
+      completion_date: "2020-10-01T04:05:06.000Z",
+      material_cost: 200,
+      labor_cost: 300,
+      total_cost: 500,
+      description_of_work: 'Warehouse renovation',
+      client_company_name: 'Amazon',
+      business_address: '12 Tree Ave',
+      business_address_line_2: null,
+      business_city: 'Seattle',
+      business_state: 'WA',
+      business_zip_code: '99900',
+      additional_info: 'Received partial payment',
+      user_id: '12345',
+      status: 'Good Standing'
+    }
+
+    const mockChangeView = jest.fn()
+
+    render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <AdminJobDetails
+            jobDetails={jobDetails}
+            changeView={mockChangeView}
+            handleStatusChange={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    )
+  
+    const backButton = screen.getByRole('button', { name: 'Back' });
+    const jobTypeLabel = screen.getByText('Job Type:');
+    const jobType = screen.getByText('Labor & Materials');
+    const siteNameLabel = screen.getByText("Job Site Name:");
+    const siteName = screen.getByText("Home");
+    const siteContactLabel = screen.getByText('Job Site Contact Name:');
+    const siteContact = screen.getByText('Taryn');
+    const jobSiteAddressLabel = screen.getByText('Job Site Address:', { exact: false })
+    const jobSiteAddress = screen.getByText("200 Washington St", { exact: false });
+    const jobSiteAddressCity = screen.getByText("Denver", { exact: false });
+    const jobSiteAddressState = screen.getByText("CO,", { exact: false });
+    const jobSiteAddressZip = screen.getByText("80201", { exact: false });
+    const companyNameLabel = screen.getByText('Company Name:');
+    const companyName = screen.getByText('Amazon');
+    const businessAddressLabel = screen.getByText("Business Address:")
+    const businessAddress = screen.getByText("12 Tree Ave", { exact: false })
+    const businessAddressCity = screen.getByText("Seattle", { exact: false });
+    const businessAddressState = screen.getByText("WA,", { exact: false });
+    const businessAddressZip = screen.getByText("99900", { exact: false });
+    const jobDescriptionLabel = screen.getByText("Job Description:");
+    const jobDescription = screen.getByText("Warehouse renovation");
+    const additionalInfoLabel = screen.getByText("Additional Info:");
+    const additionalInfo = screen.getByText("Received partial payment");
+    const completionLabel = screen.getByText("Date of Substantial Completion:");
+    const laborCostLabel = screen.getByText("Labor Cost:");
+    const laborCost = screen.getByText("$300");
+    const materialsCostLabel = screen.getByText("Materials Cost:");
+    const materialsCost = screen.getByText("$200");
+    const totalLabel = screen.getByText("Total Cost:");
+    const total = screen.getByText("$500");
+
+    expect(backButton).toBeInTheDocument();
+    expect(jobSiteAddressLabel).toBeInTheDocument()
+    expect(jobSiteAddress).toBeInTheDocument()
+    expect(jobSiteAddressCity).toBeInTheDocument()
+    expect(jobSiteAddressState).toBeInTheDocument()
+    expect(jobSiteAddressZip).toBeInTheDocument()
+    expect(businessAddressLabel).toBeInTheDocument()
+    expect(businessAddress).toBeInTheDocument()
+    expect(businessAddressCity).toBeInTheDocument()
+    expect(businessAddressState).toBeInTheDocument()
+    expect(businessAddressZip).toBeInTheDocument()
+    expect(jobTypeLabel).toBeInTheDocument();
+    expect(jobType).toBeInTheDocument();
+    expect(siteName).toBeInTheDocument();
+    expect(siteNameLabel).toBeInTheDocument();
+    expect(siteContact).toBeInTheDocument();
+    expect(siteContactLabel).toBeInTheDocument();
+    expect(companyNameLabel).toBeInTheDocument();
+    expect(companyName).toBeInTheDocument();
+    expect(jobDescriptionLabel).toBeInTheDocument();
+    expect(jobDescription).toBeInTheDocument();
+    expect(additionalInfoLabel).toBeInTheDocument();
+    expect(additionalInfo).toBeInTheDocument();
+    expect(completionLabel).toBeInTheDocument();
+    expect(laborCostLabel).toBeInTheDocument();
+    expect(laborCost).toBeInTheDocument();
+    expect(materialsCostLabel).toBeInTheDocument();
+    expect(materialsCost).toBeInTheDocument();
+    expect(totalLabel).toBeInTheDocument();
+    expect(total).toBeInTheDocument();
+  });
+
+  it('should take user to previous page when back button is clicked', async () => {
+
+    const store = mockStore({
+      adminJobList: [
+        {
+          id: "1",
+          job_type: 'Labor & Materials',
+          job_site_name: 'Home',
+          job_site_contact_name: 'Taryn',
+          job_site_address: '200 Washington St.',
+          job_site_address_line_2: null,
+          job_site_city: 'Denver',
+          job_site_state: 'CO',
+          job_site_zip_code: '80201',
+          completion_date: "2020-10-01T04:05:06.000Z",
+          material_cost: 200,
+          labor_cost: 300,
+          total_cost: 500,
+          description_of_work: 'Warehouse renovation',
+          client_company_name: 'Amazon',
+          business_address: '12 Tree Ave',
+          business_address_line_2: null,
+          business_city: 'Seattle',
+          business_state: 'WA',
+          business_zip_code: '99900',
+          additional_info: 'Received partial payment',
+          user_id: '12345',
+          status: 'Good Standing'
+        },
+      ]
+    })
+
+    const jobDetails = {
+      id: "1",
+      job_type: 'Labor & Materials',
+      job_site_name: 'Home',
+      job_site_contact_name: 'Taryn',
+      job_site_address: '200 Washington St.',
+      job_site_address_line_2: null,
+      job_site_city: 'Denver',
+      job_site_state: 'CO',
+      job_site_zip_code: '80201',
+      completion_date: "2020-10-01T04:05:06.000Z",
+      material_cost: 200,
+      labor_cost: 300,
+      total_cost: 500,
+      description_of_work: 'Warehouse renovation',
+      client_company_name: 'Amazon',
+      business_address: '12 Tree Ave',
+      business_address_line_2: null,
+      business_city: 'Seattle',
+      business_state: 'WA',
+      business_zip_code: '99900',
+      additional_info: 'Received partial payment',
+      user_id: '12345',
+      status: 'Good Standing'
+    }
+
+    const mockChangeView = jest.fn()
+
+    render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <AdminJobDetails
+            jobDetails={jobDetails}
+            changeView={mockChangeView}
+            handleStatusChange={jest.fn()}
+          />
+        </MemoryRouter>
+      </Provider>
+    )
+
+    const backButton = screen.getByRole('button', { name: 'Back' });
+ 
+    fireEvent.click(backButton)
+    expect(mockChangeView).toHaveBeenCalled()
+  })
+})

--- a/src/containers/AdminHomepage/AdminHomepage.js
+++ b/src/containers/AdminHomepage/AdminHomepage.js
@@ -3,7 +3,7 @@ import { DataGrid } from '@material-ui/data-grid';
 import Button from '@material-ui/core/Button';
 import { useSelector, useDispatch } from 'react-redux';
 import { getAllUsersJobs } from '../../helpers/apiCalls'
-import { setErrorMsg, resetErrorMsg } from '../../actions/actions'
+import { setAdminJobList, setErrorMsg, resetErrorMsg } from '../../actions/actions'
 
 
 function AdminHomepage() {
@@ -13,7 +13,7 @@ function AdminHomepage() {
   useEffect(() => {
     getAllUsersJobs(user.attributes.token)
       .then(data => {
-        console.log(data.data)
+        dispatch(setAdminJobList(data.data))
         dispatch(resetErrorMsg());
       })
       .catch(error => {

--- a/src/containers/AdminHomepage/AdminHomepage.js
+++ b/src/containers/AdminHomepage/AdminHomepage.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { DataGrid } from '@material-ui/data-grid';
+
 
 function AdminHomepage() {
 

--- a/src/containers/AdminHomepage/AdminHomepage.js
+++ b/src/containers/AdminHomepage/AdminHomepage.js
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react'; 
+import React, { useEffect, useState } from 'react'; 
+import AdminJobDetails from '../../components/AdminJobDetails/AdminJobDetails'
 import { DataGrid } from '@material-ui/data-grid';
 import Button from '@material-ui/core/Button';
 import { useSelector, useDispatch } from 'react-redux';
@@ -8,6 +9,8 @@ import { setAdminJobList, setErrorMsg, resetErrorMsg } from '../../actions/actio
 
 function AdminHomepage() {
   const dispatch = useDispatch();
+  const [viewDashboard, changeView] = useState(true)
+  const [job, selectJob] = useState({})
   const user = useSelector(state => state.user)
   const jobList = useSelector(state => state.adminJobList)
  
@@ -22,19 +25,25 @@ function AdminHomepage() {
       })
   }, [dispatch, user.attributes.token])
 
+  const handleClick = (jobDetails) => {
+    changeView(false)
+    selectJob(jobDetails)
+  }
+
   const columns = [
     {
       field: 'openJobButton',
       headerName: 'View Job Details',
       width: 150,
-      renderCell: () => (
+      renderCell: (RowParams) => (
           <Button
             variant="contained"
             color="primary"
             size="small"
             style={{ marginLeft: 16 }}
+            onClick={() => handleClick(RowParams.data)}
           >
-            Open
+          OPEN
         </Button>
       ),
     },
@@ -66,18 +75,25 @@ function AdminHomepage() {
       width: 200,
     },
   ];
-  
+
   return(
     <div>
-      <h2>Admin Dashboard</h2>
-      <div style={{ height: 400, width: '100%', textAlign: 'left', marginLeft: 16 }}>
-        <DataGrid
-          rows={jobList} 
-          columns={columns}
-          pageSize={5}  
-          sortingOrder={['asc', 'desc', null]}
-        />
-      </div>
+      { !viewDashboard &&
+        <AdminJobDetails jobDetails={job} changeView={changeView} />
+      }
+      { viewDashboard &&
+      <>
+        <h2>Admin Dashboard</h2>
+        <div style={{ height: 400, width: '100%', textAlign: 'left', marginLeft: 16 }}>
+          <DataGrid
+            rows={jobList} 
+            columns={columns}
+            pageSize={5}  
+            sortingOrder={['asc', 'desc', null]}  
+          />
+        </div>
+      </>
+      }
     </div>
   )
 }

--- a/src/containers/AdminHomepage/AdminHomepage.js
+++ b/src/containers/AdminHomepage/AdminHomepage.js
@@ -6,7 +6,6 @@ import { useSelector, useDispatch } from 'react-redux';
 import { getAllUsersJobs } from '../../helpers/apiCalls'
 import { setAdminJobList, setErrorMsg, resetErrorMsg } from '../../actions/actions'
 
-
 function AdminHomepage() {
   const dispatch = useDispatch();
   const [viewDashboard, changeView] = useState(true)
@@ -28,6 +27,10 @@ function AdminHomepage() {
   const handleClick = (jobDetails) => {
     changeView(false)
     selectJob(jobDetails)
+  }
+
+  const handleStatusChange = () => {
+    // handle status changes w/ PATCH
   }
 
   const columns = [
@@ -80,9 +83,6 @@ function AdminHomepage() {
 
   return(
     <div>
-      { !viewDashboard &&
-        <AdminJobDetails jobDetails={job} changeView={changeView} />
-      }
       { viewDashboard &&
       <>
         <h2>Admin Dashboard</h2>
@@ -95,6 +95,9 @@ function AdminHomepage() {
           />
         </div>
       </>
+      }
+      { !viewDashboard &&
+        <AdminJobDetails jobDetails={job} changeView={changeView} handleStatusChange={handleStatusChange} />
       }
     </div>
   )

--- a/src/containers/AdminHomepage/AdminHomepage.js
+++ b/src/containers/AdminHomepage/AdminHomepage.js
@@ -51,7 +51,7 @@ function AdminHomepage() {
       ),
     },
     {
-      field: 'client_name',
+      field: 'users_name',
       headerName: 'Client Name',
       width: 200,
     },
@@ -66,19 +66,14 @@ function AdminHomepage() {
       headerName: 'Date of Substantial Completion',
       valueFormatter: (params) =>
         params.value.split('T')[0],
-      width: 150,
+      width: 250,
     },
     {
       field: 'status',
       headerName: 'Job Status',
       sortable: true,
       width: 150,
-    },
-    {
-      field: 'job_site_contact_name',
-      headerName: 'Job Site Contact',
-      width: 200,
-    },
+    }
   ];
 
   return(

--- a/src/containers/AdminHomepage/AdminHomepage.js
+++ b/src/containers/AdminHomepage/AdminHomepage.js
@@ -9,7 +9,8 @@ import { setAdminJobList, setErrorMsg, resetErrorMsg } from '../../actions/actio
 function AdminHomepage() {
   const dispatch = useDispatch();
   const user = useSelector(state => state.user)
-
+  const jobList = useSelector(state => state.adminJobList)
+ 
   useEffect(() => {
     getAllUsersJobs(user.attributes.token)
       .then(data => {
@@ -17,9 +18,9 @@ function AdminHomepage() {
         dispatch(resetErrorMsg());
       })
       .catch(error => {
-        dispatch(setErrorMsg('Sorry, it looks like we are having some trouble retrieving your information. Refresh or try again later.'))
+        dispatch(setErrorMsg('Sorry, it looks like we are having some trouble retrieving the data. Please refresh or try again later.'))
       })
-  })
+  }, [dispatch, user.attributes.token])
 
   const columns = [
     {
@@ -40,7 +41,12 @@ function AdminHomepage() {
     {
       field: 'client_name',
       headerName: 'Client Name',
-      width: 250,
+      width: 200,
+    },
+    {
+      field: 'job_type',
+      headerName: 'Job Type',
+      width: 110,
     },
     {
       field: 'completion_date',
@@ -49,54 +55,24 @@ function AdminHomepage() {
       width: 200,
     },
     {
-      field: 'job_status',
+      field: 'status',
       headerName: 'Job Status',
       sortable: true,
+      width: 150,
+    },
+    {
+      field: 'job_site_contact_name',
+      headerName: 'Job Site Contact',
       width: 200,
     },
   ];
-
-  // sample data for UI testing
-  // need an array of objects
-  const rows = [
-    {
-      id: 1,
-      completion_date: '23/10/2020',
-      client_name: 'Bruce Craft',
-      job_status: 'NOI Requested',
-    },
-    {
-      id: 2,
-      completion_date: '12/11/2020',
-      client_name: 'Rachel McDee',
-      job_status: 'Lien Requested'
-    },
-    {
-      id: 3,
-      completion_date: '29/10/2020',
-      client_name: 'Nelly Grunge',
-      job_status: 'Lien Filed'
-    },
-    {
-      id: 4,
-      completion_date: '10/11/2020',
-      client_name: 'Beau Tiger',
-      job_status: 'Lien Requested'
-    },
-    {
-      id: 5,
-      completion_date: '03/11/2020',
-      client_name: 'Mary Lee Oswald',
-      job_status: 'NOI Requested'
-    },
-  ];
-
+  
   return(
     <div>
       <h2>Admin Dashboard</h2>
       <div style={{ height: 400, width: '100%', textAlign: 'left', marginLeft: 16 }}>
         <DataGrid
-          rows={rows} 
+          rows={jobList} 
           columns={columns}
           pageSize={5}  
           sortingOrder={['asc', 'desc', null]}

--- a/src/containers/AdminHomepage/AdminHomepage.js
+++ b/src/containers/AdminHomepage/AdminHomepage.js
@@ -73,6 +73,11 @@ function AdminHomepage() {
       headerName: 'Job Status',
       sortable: true,
       width: 150,
+    },
+    {
+      field: 'job_site_contact_name',
+      headerName: 'Job Site Contact',
+      width: 200,
     }
   ];
 

--- a/src/containers/AdminHomepage/AdminHomepage.js
+++ b/src/containers/AdminHomepage/AdminHomepage.js
@@ -82,7 +82,7 @@ function AdminHomepage() {
   ];
 
   return(
-    <div>
+    <div className='admin-dashboard'>
       { viewDashboard &&
       <>
         <h2>Admin Dashboard</h2>

--- a/src/containers/AdminHomepage/AdminHomepage.js
+++ b/src/containers/AdminHomepage/AdminHomepage.js
@@ -61,7 +61,9 @@ function AdminHomepage() {
       field: 'completion_date',
       type: 'date',
       headerName: 'Date of Substantial Completion',
-      width: 200,
+      valueFormatter: (params) =>
+        params.value.split('T')[0],
+      width: 150,
     },
     {
       field: 'status',

--- a/src/containers/AdminHomepage/AdminHomepage.js
+++ b/src/containers/AdminHomepage/AdminHomepage.js
@@ -1,9 +1,25 @@
-import React from 'react';
+import React, { useEffect } from 'react'; 
 import { DataGrid } from '@material-ui/data-grid';
 import Button from '@material-ui/core/Button';
+import { useSelector, useDispatch } from 'react-redux';
+import { getAllUsersJobs } from '../../helpers/apiCalls'
+import { setErrorMsg, resetErrorMsg } from '../../actions/actions'
 
 
 function AdminHomepage() {
+  const dispatch = useDispatch();
+  const user = useSelector(state => state.user)
+
+  useEffect(() => {
+    getAllUsersJobs(user.attributes.token)
+      .then(data => {
+        console.log(data.data)
+        dispatch(resetErrorMsg());
+      })
+      .catch(error => {
+        dispatch(setErrorMsg('Sorry, it looks like we are having some trouble retrieving your information. Refresh or try again later.'))
+      })
+  })
 
   const columns = [
     {
@@ -41,6 +57,7 @@ function AdminHomepage() {
   ];
 
   // sample data for UI testing
+  // need an array of objects
   const rows = [
     {
       id: 1,

--- a/src/containers/AdminHomepage/AdminHomepage.js
+++ b/src/containers/AdminHomepage/AdminHomepage.js
@@ -1,12 +1,90 @@
 import React from 'react';
 import { DataGrid } from '@material-ui/data-grid';
+import Button from '@material-ui/core/Button';
 
 
 function AdminHomepage() {
 
+  const columns = [
+    {
+      field: 'openJobButton',
+      headerName: 'View Job Details',
+      width: 150,
+      renderCell: () => (
+          <Button
+            variant="contained"
+            color="primary"
+            size="small"
+            style={{ marginLeft: 16 }}
+          >
+            Open
+        </Button>
+      ),
+    },
+    {
+      field: 'client_name',
+      headerName: 'Client Name',
+      width: 250,
+    },
+    {
+      field: 'completion_date',
+      type: 'date',
+      headerName: 'Date of Substantial Completion',
+      width: 200,
+    },
+    {
+      field: 'job_status',
+      headerName: 'Job Status',
+      sortable: true,
+      width: 200,
+    },
+  ];
+
+  // sample data for UI testing
+  const rows = [
+    {
+      id: 1,
+      completion_date: '23/10/2020',
+      client_name: 'Bruce Craft',
+      job_status: 'NOI Requested',
+    },
+    {
+      id: 2,
+      completion_date: '12/11/2020',
+      client_name: 'Rachel McDee',
+      job_status: 'Lien Requested'
+    },
+    {
+      id: 3,
+      completion_date: '29/10/2020',
+      client_name: 'Nelly Grunge',
+      job_status: 'Lien Filed'
+    },
+    {
+      id: 4,
+      completion_date: '10/11/2020',
+      client_name: 'Beau Tiger',
+      job_status: 'Lien Requested'
+    },
+    {
+      id: 5,
+      completion_date: '03/11/2020',
+      client_name: 'Mary Lee Oswald',
+      job_status: 'NOI Requested'
+    },
+  ];
+
   return(
     <div>
       <h2>Admin Dashboard</h2>
+      <div style={{ height: 400, width: '100%', textAlign: 'left', marginLeft: 16 }}>
+        <DataGrid
+          rows={rows} 
+          columns={columns}
+          pageSize={5}  
+          sortingOrder={['asc', 'desc', null]}
+        />
+      </div>
     </div>
   )
 }

--- a/src/containers/AdminHomepage/AdminHomepage.test.js
+++ b/src/containers/AdminHomepage/AdminHomepage.test.js
@@ -6,15 +6,74 @@ import '@testing-library/jest-dom'
 import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
+import { getAllUsersJobs } from '../../helpers/apiCalls'
+jest.mock('../../helpers/apiCalls')
 
 const middlewares = [thunk]
 const mockStore = configureMockStore(middlewares);
 
 describe('CreateUser', () => {
-  let store;
+  let allJobs, user;
 
   beforeEach(() => {
-    store = mockStore({})
+    user = {
+      id: 1,
+      attributes: {
+        name: 'Jason',
+        email: 'jason@gmail.com',
+        token: 'gjobaoifnbi34blb'
+      }
+    }
+
+    allJobs = [
+      {
+        id: "1",
+        job_type: 'labor & materials',
+        job_site_name: 'Home',
+        job_site_contact_name: 'Taryn',
+        job_site_address: '200 Washington St.', job_site_address_line_2: '', job_site_city: 'Denver',
+        job_site_state: 'CO', job_site_zip_code: '80201', completion_date: "2020-10-01T04:05:06.000Z",
+        material_cost: 200,
+        labor_cost: 200,
+        total_cost: 400,
+        description_of_work: 'blah',
+        client_company_name: 'Amazon',
+        business_address: '12 Tree Ave',
+        business_address_line_2: 'Suite 200',
+        business_city: 'Seattle',
+        business_state: 'WA', business_zip_code: '99900', additional_info: 'Amazon warehouse reno',
+        status: 'good standing'
+        
+      },
+      {
+        id: "2",
+        job_type: 'labor & materials',
+        job_site_name: 'Home',
+        job_site_contact_name: 'Taryn',
+        job_site_address: '200 Washington St.', job_site_address_line_2: '', job_site_city: 'Denver',
+        job_site_state: 'CO', job_site_zip_code: '80201', completion_date: "2020-10-01T04:05:06.000Z",
+        material_cost: 200,
+        labor_cost: 200,
+        total_cost: 400,
+        description_of_work: 'blah',
+        client_company_name: 'Microsoft',
+        business_address: '12 Tree Ave',
+        business_address_line_2: 'Suite 200',
+        business_city: 'Seattle',
+        business_state: 'WA', business_zip_code: '99900', additional_info: 'Amazon warehouse reno',
+        status: 'NOI Eligible'
+      }
+    ]
+  })
+   
+
+  it('should display the user homepage on load', () => {
+    getAllUsersJobs.mockResolvedValueOnce(allJobs)
+
+    const store = mockStore({
+      user: user,
+      adminJobList: allJobs
+    })
 
     render(
       <Provider store={store}>
@@ -23,10 +82,9 @@ describe('CreateUser', () => {
         </ MemoryRouter>
       </Provider>
     )
-  })
-  it('should display the user homepage on load', () => {
+  
     const placeholder = screen.getByText('Admin Dashboard');
 
     expect(placeholder).toBeInTheDocument()
   })
-});
+})

--- a/src/containers/AdminHomepage/AdminHomepage.test.js
+++ b/src/containers/AdminHomepage/AdminHomepage.test.js
@@ -50,7 +50,8 @@ describe('CreateUser', () => {
         job_type: 'labor & materials',
         job_site_name: 'Home',
         job_site_contact_name: 'Taryn',
-        job_site_address: '200 Washington St.', job_site_address_line_2: '', job_site_city: 'Denver',
+        job_site_address: '200 Washington St.', 
+        job_site_address_line_2: '', job_site_city: 'Denver',
         job_site_state: 'CO', job_site_zip_code: '80201', completion_date: "2020-10-01T04:05:06.000Z",
         material_cost: 200,
         labor_cost: 200,
@@ -86,5 +87,37 @@ describe('CreateUser', () => {
     const placeholder = screen.getByText('Admin Dashboard');
 
     expect(placeholder).toBeInTheDocument()
+  })
+
+  it('should display job information on the dashboard', () => {
+    getAllUsersJobs.mockResolvedValueOnce(allJobs)
+
+    const store = mockStore({
+      user: user,
+      adminJobList: allJobs
+    })
+
+    render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <AdminHomepage />
+        </ MemoryRouter>
+      </Provider>
+    )
+
+    const viewDetailsHeader = screen.getByText('View Job Details')
+    const clientNameHeader = screen.getByText('Client Name')
+    const jobTypeHeader = screen.getByText('Job Type')
+    const nextButton = screen.getByLabelText('Next page')
+    // const jobStatusHeader = screen.getByText('Job Status')
+    // const dateHeader = screen.ByText('Date of Substantial Completion', { exact: false })
+  
+
+    expect(viewDetailsHeader).toBeInTheDocument()
+    expect(clientNameHeader).toBeInTheDocument()
+    expect(jobTypeHeader).toBeInTheDocument()
+    expect(nextButton).toBeInTheDocument()
+    // expect(jobStatusHeader).toBeInTheDocument()
+    // expect(dateHeader).toBeInTheDocument()
   })
 })

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -41,7 +41,7 @@ function App() {
         <Route exact path="/admin-homepage" render={() => {
           return (
             <>
-              <Header currentPath='user' />
+              <Header currentPath={'admin'} />
               <AdminHomepage />
             </>
           )
@@ -56,7 +56,7 @@ function App() {
               dispatch(getJobInfo(jobId, dateDifference, eligibility, allJobs));
               return (
                 <>
-                  <Header />
+                  <Header currentPath={'user'} />
                   <JobDetails updateStatus={updateStatus}/>
                 </>
               )
@@ -64,7 +64,7 @@ function App() {
             <Route exact path="/addjob" render={() => {
               return (
                 <>
-                  <Header />
+                  <Header currentPath={'user'} />
                   <JobForm updateStatus={updateStatus} />
                 </>
               )
@@ -99,7 +99,7 @@ function App() {
             <Route exact path={"/filedjobs/release-eligible"} render={() => {
               return (
                 <>
-                  <Header currentPath="filed"/>
+                  <Header currentPath={"filed"}/>
                   <h2>Jobs Eligible for Lien Release</h2>
                   <Jobs />
                 </>
@@ -108,7 +108,7 @@ function App() {
             <Route exact path="/profile" render={() => {
               return (
                 <>
-                  <Header currentPath='user'/>
+                  <Header currentPath={'user'}/>
                   <Profile />
                 </>
               )
@@ -116,7 +116,7 @@ function App() {
             <Route exact path="/homepage" render={() => {
               return (
                 <>
-                  <Header currentPath='user'/>
+                  <Header currentPath={'user'} />
                   <Homepage 
                     updateStatus={updateStatus} 
                     statusUpdated={statusUpdated}
@@ -133,7 +133,7 @@ function App() {
             <Route exact path="/login" render={() => {
               return (
                 <>
-                  <Header currentPath='no-user'/>
+                  <Header currentPath={'no-user'}/>
                   <Login />
                 </>
               )
@@ -141,7 +141,7 @@ function App() {
             <Route exact path="/create-user" render={({match}) => {
               return (
                 <>
-                  <Header currentPath='no-user'/>
+                  <Header currentPath={'no-user'}/>
                   <CreateUser />
                 </>
               )

--- a/src/containers/Header/Header.js
+++ b/src/containers/Header/Header.js
@@ -26,6 +26,14 @@ function Header(props) {
           <img src={logo} className='logo' alt='lienflash logo'/>
         </Link>
       }
+      {currentPath === 'admin' &&
+        <>
+          <Link to={'/admin-homepage'} onClick={clearError}>
+            <img src={logo} className='logo' alt='lienflash logo' />
+          </Link>
+          <button className='btn logout' onClick={logout}>Log Out</button>
+        </>
+      }
       {currentPath === 'user' &&
         <>
           <Link to={'/homepage'} onClick={clearError}>
@@ -35,16 +43,27 @@ function Header(props) {
         </>
       }
         {currentPath === 'filed'&&
-            <div>
-              <NavLink to={"/filedjobs/lien-eligible"} className='nav-button' activeClassName="selected" onClick={clearError}>
-              Lien Eligible
-              </NavLink>
-              <NavLink to={'/filedjobs/release-eligible'} className='nav-button' activeClassName="selected" onClick={clearError}>
-                Release Eligible
-              </NavLink>
-            </div>
+        <>
+          <Link to={'/homepage'} onClick={clearError}>
+            <img src={logo} className='logo' alt='lienflash logo'/>
+          </Link>
+          <button className='btn logout' onClick={logout}>Log Out</button>
+          <div>
+            <NavLink to={"/filedjobs/lien-eligible"} className='nav-button' activeClassName="selected" onClick={clearError}>
+            Lien Eligible
+            </NavLink>
+            <NavLink to={'/filedjobs/release-eligible'} className='nav-button' activeClassName="selected" onClick={clearError}>
+              Release Eligible
+            </NavLink>
+          </div>
+        </>
         }
         {currentPath === 'eligible'&&
+          <>
+            <Link to={'/homepage'} onClick={clearError}>
+              <img src={logo} className='logo' alt='lienflash logo' />
+            </Link>
+            <button className='btn logout' onClick={logout}>Log Out</button>
             <div>
               <NavLink to={'/eligiblejobs/grace-period'} className='nav-button' activeClassName="selected" onClick={clearError}>
                 Grace Period
@@ -53,6 +72,7 @@ function Header(props) {
                 NOI Eligible
               </NavLink>
             </div>
+          </>
         }
     </header>
   )

--- a/src/helpers/apiCalls.js
+++ b/src/helpers/apiCalls.js
@@ -1,4 +1,3 @@
-
 export const getUserProfile = async (token) => {
   return await fetch(`https://lienflash-be.herokuapp.com/api/v1/users/verified`, {
   method: "GET",
@@ -129,4 +128,22 @@ export const createUser = async (info) => {
       return response.json();
     }
   })
+}
+
+export const getAllUsersJobs = (token) => {
+  return fetch(`https://lienflash-be.herokuapp.com/api/v1/admin/jobs`, {
+    method: "GET",
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'Authorization': `Bearer ${token}`
+    }
+  })
+    .then((response) => {
+      if (!response.ok) {
+        throw Error(response.statusText);
+      } else {
+        return response.json();
+      }
+    })
 }

--- a/src/reducers/adminJobListReducer.js
+++ b/src/reducers/adminJobListReducer.js
@@ -1,12 +1,11 @@
 const adminJobListReducer = ( state=[], action) => {
-  console.log(action.type)
   switch(action.type) {
     case 'ADMIN_JOB_LIST':
-    return action.jobs.map(job => {
-      let attributes = job.attributes
-      attributes['id'] = job.id
-      return attributes
-    })
+      return action.jobs.map(job => {
+        let attributes = job.attributes
+        attributes['id'] = job.id
+        return attributes
+      })
     default: 
       return state
   }

--- a/src/reducers/adminJobListReducer.js
+++ b/src/reducers/adminJobListReducer.js
@@ -2,7 +2,11 @@ const adminJobListReducer = ( state=[], action) => {
   console.log(action.type)
   switch(action.type) {
     case 'ADMIN_JOB_LIST':
-    return action.jobs.map(job => job.attributes)
+    return action.jobs.map(job => {
+      let attributes = job.attributes
+      attributes['id'] = job.id
+      return attributes
+    })
     default: 
       return state
   }

--- a/src/reducers/adminJobListReducer.js
+++ b/src/reducers/adminJobListReducer.js
@@ -1,0 +1,11 @@
+const adminJobListReducer = ( state=[], action) => {
+  console.log(action.type)
+  switch(action.type) {
+    case 'ADMIN_JOB_LIST':
+    return action.jobs.map(job => job.attributes)
+    default: 
+      return state
+  }
+}
+
+export default adminJobListReducer

--- a/src/reducers/adminJobListReducer.test.js
+++ b/src/reducers/adminJobListReducer.test.js
@@ -1,0 +1,108 @@
+import adminJobListReducer from './adminJobListReducer.js'
+
+describe('adminJobListReducer', () => {
+  it('should return the initial state', () => {
+    const expected = [];
+    const result = adminJobListReducer(undefined, []);
+
+    expect(result).toEqual(expected)
+  })
+
+  it('should return the correct state if action is ADMIN_JOB_LIST', () => {
+    const initialState = [];
+    const action = {
+      type: 'ADMIN_JOB_LIST',
+      jobs: [
+        {
+          id: "1",
+          type: "job",
+          attributes: {
+            job_type: 'Labor',
+            job_site_name: 'Home',
+            job_site_contact_name: 'Taryn',
+            job_site_address: '200 Washington St.',
+            job_site_address_line_2: '', job_site_city: 'Denver',
+            job_site_state: 'CO', job_site_zip_code: '80201', completion_date: "2020-10-01T04:05:06.000Z",
+            material_cost: 200,
+            labor_cost: 200,
+            total_cost: 400,
+            description_of_work: 'blah',
+            client_company_name: 'Amazon',
+            business_address: '12 Tree Ave',
+            business_address_line_2: 'Suite 200',
+            business_city: 'Seattle',
+            business_state: 'WA', business_zip_code: '99900', additional_info: 'Amazon warehouse reno',
+            status: 'Good Standing',
+          }
+        }, 
+        {
+          id: "2",
+          type: "job",
+          attributes: {
+            job_type: 'Labor',
+            job_site_name: 'Home',
+            job_site_contact_name: 'Taryn',
+            job_site_address: '200 Washington St.',
+            job_site_address_line_2: '', job_site_city: 'Denver',
+            job_site_state: 'CO', job_site_zip_code: '80201', completion_date: "2020-11-01T04:05:06.000Z",
+            material_cost: 200,
+            labor_cost: 200,
+            total_cost: 400,
+            description_of_work: 'blah',
+            client_company_name: 'Amazon',
+            business_address: '12 Tree Ave',
+            business_address_line_2: 'Suite 200',
+            business_city: 'Seattle',
+            business_state: 'WA', business_zip_code: '99900', additional_info: 'Amazon warehouse reno',
+            status: 'NOI Eligible',
+          }
+        }
+      ]
+    }
+
+    const newState = [
+        {
+          id: "1",
+          job_type: 'Labor',
+          job_site_name: 'Home',
+          job_site_contact_name: 'Taryn',
+          job_site_address: '200 Washington St.',
+          job_site_address_line_2: '', job_site_city: 'Denver',
+          job_site_state: 'CO', job_site_zip_code: '80201', completion_date: "2020-10-01T04:05:06.000Z",
+          material_cost: 200,
+          labor_cost: 200,
+          total_cost: 400,
+          description_of_work: 'blah',
+          client_company_name: 'Amazon',
+          business_address: '12 Tree Ave',
+          business_address_line_2: 'Suite 200',
+          business_city: 'Seattle',
+          business_state: 'WA', business_zip_code: '99900', additional_info: 'Amazon warehouse reno',
+          status: 'Good Standing',
+        }, 
+        {
+          id: "2",
+          job_type: 'Labor',
+          job_site_name: 'Home',
+          job_site_contact_name: 'Taryn',
+          job_site_address: '200 Washington St.',
+          job_site_address_line_2: '', job_site_city: 'Denver',
+          job_site_state: 'CO', job_site_zip_code: '80201', completion_date: "2020-11-01T04:05:06.000Z",
+          material_cost: 200,
+          labor_cost: 200,
+          total_cost: 400,
+          description_of_work: 'blah',
+          client_company_name: 'Amazon',
+          business_address: '12 Tree Ave',
+          business_address_line_2: 'Suite 200',
+          business_city: 'Seattle',
+          business_state: 'WA', business_zip_code: '99900', additional_info: 'Amazon warehouse reno',
+          status: 'NOI Eligible',
+        }
+      ]
+    
+    const result = adminJobListReducer(initialState, action)
+
+    expect(result).toEqual(newState)
+  })
+});

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -3,12 +3,14 @@ import jobsReducer from './jobsReducer.js';
 import jobInfoReducer from './jobInfoReducer.js';
 import errorReducer from './errorReducer.js';
 import userReducer from './userReducer.js';
+import adminJobListReducer from './adminJobListReducer.js';
 
 const rootReducer = combineReducers({
   allJobs: jobsReducer,
   jobInfo: jobInfoReducer,
   user: userReducer,
-  errorMessage: errorReducer
+  errorMessage: errorReducer,
+  adminJobList: adminJobListReducer
 });
 
 export default rootReducer;

--- a/src/scss/_adminHomepage.scss
+++ b/src/scss/_adminHomepage.scss
@@ -1,0 +1,4 @@
+.admin-dashboard {
+  margin-left: -10%;
+  margin-right: -10%;
+}

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -8,5 +8,6 @@
 @import 'jobCard';
 @import 'jobDetails'; 
 @import 'login';
+@import 'adminHomepage';
 @import 'header';
 @import 'media_queries';


### PR DESCRIPTION
#### What’s this PR do?
- Sets up admin dashboard using the Material UI Data Grid
- Creates adminJobDetails component which displays all of the details for a job 
- Sets up buttons/functionality to enable admin to update the status of a job
- Adds tests for admin components
- Fixes code to ensure logo is rendered on all pages
#### Where should the reviewer start?
- adminHomepage
#### How should this be manually tested?
- In browser log in as the admin
#### Any background context you want to provide?
- The `handleStatusChange` method in adminHomePage needs to be build out once the back-end has setup all of the status and functionality to handle the changes from the admin.
- Currently both the admin-homepage and adminJobDetails pages are setup on the same route and just toggling between the different views. I can change this if we think it'll add value to have a separate route.
#### What are the relevant tickets?
- Resolves #87 
- Progress toward #86 
#### Questions:
n/a
#### Need Help/Support

- [x] checked to see it passes all tests
